### PR TITLE
Remove horizontal separator which messes up godoc

### DIFF
--- a/raw/float.go
+++ b/raw/float.go
@@ -18,7 +18,6 @@ func MarshalFloat32(v float32, bs []byte) (n int) {
 	return marshalInteger32(math.Float32bits(v), bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalFloat64 parses a MUS-encoded (Raw) float64 value from bs.
 //
 // In addition to the float64 value, returns the number of used bytes and the
@@ -43,7 +42,6 @@ func UnmarshalFloat32(bs []byte) (v float32, n int, err error) {
 	return math.Float32frombits(uv), n, nil
 }
 
-// -----------------------------------------------------------------------------
 // SizeFloat64 returns the size of a MUS-encoded (Raw) float64 value.
 func SizeFloat64(v float64) (n int) {
 	return sizeNum64(v)
@@ -54,7 +52,6 @@ func SizeFloat32(v float32) (n int) {
 	return sizeNum32(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipFloat64 skips a MUS-encoded (Raw) float64 value.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice error.

--- a/raw/int.go
+++ b/raw/int.go
@@ -52,7 +52,6 @@ func MarshalInt(v int, bs []byte) (n int) {
 	return marshalInt(v, bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalInt64 parses a MUS-encoded (Raw) int64 value from bs.
 //
 // In addition to the int64 value, returns the number of used bytes and the
@@ -93,7 +92,6 @@ func UnmarshalInt(bs []byte) (v int, n int, err error) {
 	return unmarshalInt(bs)
 }
 
-// -----------------------------------------------------------------------------
 // SizeInt64 returns the size of a MUS-encoded (Raw) int64 value.
 func SizeInt64(v int64) (n int) {
 	return sizeNum64(v)
@@ -119,7 +117,6 @@ func SizeInt(v int) (n int) {
 	return sizeInt(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipInt64 skips a MUS-encoded (Raw) int64 value.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice error.

--- a/raw/integer.go
+++ b/raw/integer.go
@@ -36,7 +36,6 @@ func marshalInteger8[T com.Integer8](t T, bs []byte) int {
 	return com.Num8RawSize
 }
 
-// -----------------------------------------------------------------------------
 func unmarshalInteger64[T com.Integer64](bs []byte) (T, int, error) {
 	var t T
 	if len(bs) < com.Num64RawSize {
@@ -83,7 +82,6 @@ func unmarshalInteger8[T com.Integer8](bs []byte) (T, int, error) {
 	return T(bs[0]), com.Num8RawSize, nil
 }
 
-// -----------------------------------------------------------------------------
 func sizeNum64[T com.Num64](t T) int {
 	return com.Num64RawSize
 }
@@ -100,7 +98,6 @@ func sizeInteger8[T com.Integer8](t T) int {
 	return com.Num8RawSize
 }
 
-// -----------------------------------------------------------------------------
 func skipInteger64(bs []byte) (int, error) {
 	if len(bs) < com.Num64RawSize {
 		return 0, mus.ErrTooSmallByteSlice

--- a/raw/uint.go
+++ b/raw/uint.go
@@ -52,7 +52,6 @@ func MarshalUint(v uint, bs []byte) (n int) {
 	return marshalUint(v, bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalUint64 parses a MUS-encoded (Raw) uint64 value from bs.
 //
 // In addition to the uint64, returns the number of used bytes and the
@@ -93,7 +92,6 @@ func UnmarshalUint(bs []byte) (v uint, n int, err error) {
 	return unmarshalUint(bs)
 }
 
-// -----------------------------------------------------------------------------
 // SizeUint64 returns the size of a MUS-encoded (Raw) uint64 value.
 func SizeUint64(v uint64) (n int) {
 	return sizeNum64(v)
@@ -119,7 +117,6 @@ func SizeUint(v uint) (n int) {
 	return sizeUint(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipUint64 skips a MUS-encoded (Raw) uint64.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice error.

--- a/unsafe/float.go
+++ b/unsafe/float.go
@@ -20,7 +20,6 @@ func MarshalFloat32(v float32, bs []byte) (n int) {
 	return marshalInteger32(math.Float32bits(v), bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalFloat64 parses a MUS-encoded (Raw) float64 value from bs.
 //
 // In addition to the float64 value, returns the number of used bytes and the
@@ -45,7 +44,6 @@ func UnmarshalFloat32(bs []byte) (v float32, n int, err error) {
 	return math.Float32frombits(uv), n, nil
 }
 
-// -----------------------------------------------------------------------------
 // SizeFloat64 returns the size of a MUS-encoded (Raw) float64 value.
 func SizeFloat64(v float64) (n int) {
 	return raw.SizeFloat64(v)
@@ -56,7 +54,6 @@ func SizeFloat32(v float32) (n int) {
 	return raw.SizeFloat32(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipFloat64 skips a MUS-encoded (Raw) float64 value.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice error.

--- a/unsafe/int.go
+++ b/unsafe/int.go
@@ -53,7 +53,6 @@ func MarshalInt(v int, bs []byte) (n int) {
 	return marshalInt(v, bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalInt64 parses a MUS-encoded (Raw) int64 value from bs.
 //
 // In addition to the int64 value, returns the number of used bytes and the
@@ -94,7 +93,6 @@ func UnmarshalInt(bs []byte) (v int, n int, err error) {
 	return unmarshalInt(bs)
 }
 
-// -----------------------------------------------------------------------------
 // SizeInt64 returns the size of a MUS-encoded (Raw) int64 value.
 func SizeInt64(v int64) (n int) {
 	return raw.SizeInt64(v)
@@ -120,7 +118,6 @@ func SizeInt(v int) (n int) {
 	return sizeInt(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipInt64 skips a MUS-encoded (Raw) int64 value.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice.

--- a/unsafe/integer.go
+++ b/unsafe/integer.go
@@ -28,7 +28,6 @@ func marshalInteger8[T com.Integer8](t T, bs []byte) (n int) {
 	return com.Num8RawSize
 }
 
-// -----------------------------------------------------------------------------
 func unmarshalInteger64[T com.Integer64](bs []byte) (t T, n int, err error) {
 	if len(bs) < com.Num64RawSize {
 		return t, 0, mus.ErrTooSmallByteSlice

--- a/unsafe/uint.go
+++ b/unsafe/uint.go
@@ -53,7 +53,6 @@ func MarshalUint(v uint, bs []byte) (n int) {
 	return marshalUint(v, bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalUint64 parses a MUS-encoded (Raw) uint64 value from bs.
 //
 // In addition to the uint64 value, returns the number of used bytes and the
@@ -94,7 +93,6 @@ func UnmarshalUint(bs []byte) (v uint, n int, err error) {
 	return unmarshalUint(bs)
 }
 
-// -----------------------------------------------------------------------------
 // SizeUint64 returns the size of a MUS-encoded (Raw) uint64 value.
 func SizeUint64(v uint64) (n int) {
 	return raw.SizeUint64(v)
@@ -120,7 +118,6 @@ func SizeUint(v uint) (n int) {
 	return sizeUint((v))
 }
 
-// -----------------------------------------------------------------------------
 // SkipUint64 skips a MUS-encoded (Raw) uint64.
 //
 // Returns the number of skiped bytes and the mus.ErrTooSmallByteSlice error.

--- a/varint/float.go
+++ b/varint/float.go
@@ -16,7 +16,6 @@ func MarshalFloat32(v float32, bs []byte) int {
 	return MarshalUint32(math.Float32bits(v), bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalFloat64 parses a MUS-encoded (Varint) float64 value from bs.
 //
 // In addition to the float64 value, returns the number of used bytes and one of
@@ -43,7 +42,6 @@ func UnmarshalFloat32(bs []byte) (v float32, n int, err error) {
 	return
 }
 
-// -----------------------------------------------------------------------------
 // SizeFloat64 returns the size of a MUS-encoded (Varint) float64 value.
 func SizeFloat64(v float64) (size int) {
 	return SizeUint64(math.Float64bits(v))
@@ -54,7 +52,6 @@ func SizeFloat32(v float32) (size int) {
 	return SizeUint32(math.Float32bits(v))
 }
 
-// -----------------------------------------------------------------------------
 // SkipFloat64 skips a MUS-encoded (Varint) float64 value.
 //
 // Returns the number of skiped bytes and one of the mus.ErrTooSmallByteSlice or

--- a/varint/int.go
+++ b/varint/int.go
@@ -39,7 +39,6 @@ func MarshalInt(v int, bs []byte) (n int) {
 	return marshalUint(uint(EncodeZigZag(v)), bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalInt64 parses a MUS-encoded (Varint) int64 value from bs.
 //
 // In addition to the int64 value, returns the number of used bytes and one of
@@ -100,7 +99,6 @@ func UnmarshalInt(bs []byte) (v int, n int, err error) {
 	return int(DecodeZigZag(uv)), n, nil
 }
 
-// -----------------------------------------------------------------------------
 // SizeInt64 returns the size of a MUS-encoded (Varint) int64 value.
 func SizeInt64(v int64) int {
 	return sizeUint(uint64(EncodeZigZag(v)))
@@ -126,7 +124,6 @@ func SizeInt(v int) (size int) {
 	return SizeUint(uint(EncodeZigZag(v)))
 }
 
-// -----------------------------------------------------------------------------
 // SkipInt64 skips a MUS-encoded (Varint) int64 value.
 //
 // Returns the number of skiped bytes and one of the mus.ErrTooSmallByteSlice or
@@ -167,7 +164,6 @@ func SkipInt(bs []byte) (n int, err error) {
 	return SkipUint(bs)
 }
 
-// -----------------------------------------------------------------------------
 func EncodeZigZag[T constraints.Signed](t T) T {
 	if t < 0 {
 		return ^(t << 1)

--- a/varint/uint.go
+++ b/varint/uint.go
@@ -41,7 +41,6 @@ func MarshalUint(v uint, bs []byte) (n int) {
 	return marshalUint(v, bs)
 }
 
-// -----------------------------------------------------------------------------
 // UnmarshalUint64 parses a MUS-encoded (Varint) uint64 value from bs.
 //
 // In addition to the uint64, returns the number of used bytes and one of the
@@ -92,7 +91,6 @@ func UnmarshalUint(bs []byte) (v uint, n int, err error) {
 		bs)
 }
 
-// -----------------------------------------------------------------------------
 // SizeUint64 returns the size of a MUS-encoded uint64 value.
 func SizeUint64(v uint64) (size int) {
 	return sizeUint(v)
@@ -118,7 +116,6 @@ func SizeUint(v uint) (size int) {
 	return sizeUint(v)
 }
 
-// -----------------------------------------------------------------------------
 // SkipUint64 skips a MUS-encoded uint64.
 //
 // Returns the number of skiped bytes and one of the mus.ErrTooSmallByteSlice or


### PR DESCRIPTION
![image](https://github.com/mus-format/mus-go/assets/153052/68776b4d-b05e-429c-be4c-79733db7e74b)
