### PR TITLE
Preallocate maps to expected size

### DIFF
--- a/ord/map.go
+++ b/ord/map.go
@@ -92,7 +92,7 @@ func (s mapSer[T, V]) Unmarshal(bs []byte) (v map[T]V, n int, err error) {
 		k   T
 		val V
 	)
-	v = make(map[T]V)
+	v = make(map[T]V, length)
 	for i := 0; i < length; i++ {
 		k, n1, err = s.keySer.Unmarshal(bs[n:])
 		n += n1
@@ -182,7 +182,7 @@ func (s validMapSer[T, V]) Unmarshal(bs []byte) (v map[T]V, n int, err error) {
 		k   T
 		val V
 	)
-	v = make(map[T]V)
+	v = make(map[T]V, length)
 	for i := 0; i < length; i++ {
 		k, n1, err = s.keySer.Unmarshal(bs[n:])
 		n += n1


### PR DESCRIPTION
This can speed things up quite a bit when deserialising large maps and seems like an easy win, since the size is already available.